### PR TITLE
Make census bounds column larger

### DIFF
--- a/db/migrate/20190723184600_change_bounds_to_longtext.rb
+++ b/db/migrate/20190723184600_change_bounds_to_longtext.rb
@@ -1,0 +1,8 @@
+class ChangeBoundsToLongtext < ActiveRecord::Migration
+  def up
+    change_column :census_boundaries, :bounds, :text, null: true, limit: 4294967295
+  end
+  
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190714031500) do
+ActiveRecord::Schema.define(version: 20190723184600) do
 
   create_table "census_boundaries", force: :cascade do |t|
     t.string   "name",            limit: 255
     t.integer  "area_identifier", limit: 4
-    t.text     "bounds",          limit: 65535
+    t.text     "bounds",          limit: 4294967295
     t.string   "geo_id",          limit: 255
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.string   "geom_type",       limit: 255
   end
 


### PR DESCRIPTION
This makes the bounds column in census_boundaries into a largetext column, zip_boundaries.bounds was already largetext. Some boundaries in Washington or Idaho are too big for a normal text column