### PR TITLE
Add stats_cache table

### DIFF
--- a/db/migrate/20190526012200_add_import_indicies_to_submissions.rb
+++ b/db/migrate/20190526012200_add_import_indicies_to_submissions.rb
@@ -1,5 +1,5 @@
 class AddImportIndiciesToSubmissions < ActiveRecord::Migration
-    def change
-      add_index :submissions, [:created_at, :ip_address, :test_type]
-    end
+  def change
+    add_index :submissions, [:created_at, :ip_address, :test_type]
   end
+end

--- a/db/migrate/20190628164100_add_stats_cache_table.rb
+++ b/db/migrate/20190628164100_add_stats_cache_table.rb
@@ -16,17 +16,17 @@ class AddStatsCacheTable < ActiveRecord::Migration
       t.float :download_sua_max, null:false
       t.integer :download_sua_count, null:false
 
-      t.integer :download_0_5, null:false
-      t.integer :download_6_10, null:false
-      t.integer :download_11_20, null:false
-      t.integer :download_21_40, null:false
-      t.integer :download_40_60, null:false
-      t.integer :download_61_80, null:false
-      t.integer :download_81_100, null:false
-      t.integer :download_101_250, null:false
-      t.integer :download_251_500, null:false
-      t.integer :download_500_1000, null:false
-      t.integer :download_1001, null:false
+      t.float :download_0_5, null:false
+      t.float :download_6_10, null:false
+      t.float :download_11_20, null:false
+      t.float :download_21_40, null:false
+      t.float :download_40_60, null:false
+      t.float :download_61_80, null:false
+      t.float :download_81_100, null:false
+      t.float :download_101_250, null:false
+      t.float :download_251_500, null:false
+      t.float :download_500_1000, null:false
+      t.float :download_1001, null:false
 
       t.integer :download_less_than_5, null:false
       t.integer :download_less_than_25, null:false
@@ -43,17 +43,17 @@ class AddStatsCacheTable < ActiveRecord::Migration
       t.float :upload_sua_max, null:false
       t.integer :upload_sua_count, null:false
 
-      t.integer :upload_0_5, null:false
-      t.integer :upload_6_10, null:false
-      t.integer :upload_11_20, null:false
-      t.integer :upload_21_40, null:false
-      t.integer :upload_40_60, null:false
-      t.integer :upload_61_80, null:false
-      t.integer :upload_81_100, null:false
-      t.integer :upload_101_250, null:false
-      t.integer :upload_251_500, null:false
-      t.integer :upload_500_1000, null:false
-      t.integer :upload_1001, null:false
+      t.float :upload_0_5, null:false
+      t.float :upload_6_10, null:false
+      t.float :upload_11_20, null:false
+      t.float :upload_21_40, null:false
+      t.float :upload_40_60, null:false
+      t.float :upload_61_80, null:false
+      t.float :upload_81_100, null:false
+      t.float :upload_101_250, null:false
+      t.float :upload_251_500, null:false
+      t.float :upload_500_1000, null:false
+      t.float :upload_1001, null:false
 
       t.integer :upload_less_than_5, null:false
       t.integer :upload_less_than_25, null:false

--- a/db/migrate/20190628164100_add_stats_cache_table.rb
+++ b/db/migrate/20190628164100_add_stats_cache_table.rb
@@ -1,28 +1,68 @@
 class AddStatsCacheTable < ActiveRecord::Migration
-    def change
-      create_table :stats_cache, id: false do |t|
-        t.string :boundary_type, null:false
-        t.string :boundary_id, null:false
-        t.string :date_type, null:false
-        t.date :date_value, null:false
+  def change
+    create_table :stats_caches, id: false do |t|
+      t.string :stat_type, null:false
+      t.string :stat_id, null:false
+      t.string :date_type, null:false
+      t.date :date_value, null:false       
 
-        t.float :all_avg_upload, null:false
-        t.float :all_median_upload, null:false
-        t.integer :all_count_upload, null:false
-        t.float :all_avg_download, null:false
-        t.float :all_median_download, null:false
-        t.integer :all_count_download, null:false
-        t.float :sua_avg_upload, null:false
-        t.float :sua_median_upload, null:false
-        t.integer :sua_count_upload, null:false
-        t.float :sua_avg_download, null:false
-        t.float :sua_median_download, null:false
-        t.integer :sua_count_download, null:false
-  
-        t.timestamps null: false
-      end
+      t.float :download_avg, null:false
+      t.float :download_median, null:false
+      t.float :download_max, null:false
+      t.integer :download_count, null:false
 
-      execute "ALTER TABLE stats_cache ADD PRIMARY KEY (boundary_type, boundary_id, date_type, date_value);"
+      t.float :download_sua_avg, null:false
+      t.float :download_sua_median, null:false
+      t.float :download_sua_max, null:false
+      t.integer :download_sua_count, null:false
+
+      t.integer :download_0_5, null:false
+      t.integer :download_6_10, null:false
+      t.integer :download_11_20, null:false
+      t.integer :download_21_40, null:false
+      t.integer :download_40_60, null:false
+      t.integer :download_61_80, null:false
+      t.integer :download_81_100, null:false
+      t.integer :download_101_250, null:false
+      t.integer :download_251_500, null:false
+      t.integer :download_500_1000, null:false
+      t.integer :download_1001, null:false
+
+      t.integer :download_less_than_5, null:false
+      t.integer :download_less_than_25, null:false
+      t.integer :download_faster_than_100, null:false
+      t.integer :download_faster_than_250, null:false
+
+      t.float :upload_avg, null:false
+      t.float :upload_median, null:false
+      t.float :upload_max, null:false
+      t.integer :upload_count, null:false
+      
+      t.float :upload_sua_avg, null:false
+      t.float :upload_sua_median, null:false
+      t.float :upload_sua_max, null:false
+      t.integer :upload_sua_count, null:false
+
+      t.integer :upload_0_5, null:false
+      t.integer :upload_6_10, null:false
+      t.integer :upload_11_20, null:false
+      t.integer :upload_21_40, null:false
+      t.integer :upload_40_60, null:false
+      t.integer :upload_61_80, null:false
+      t.integer :upload_81_100, null:false
+      t.integer :upload_101_250, null:false
+      t.integer :upload_251_500, null:false
+      t.integer :upload_500_1000, null:false
+      t.integer :upload_1001, null:false
+
+      t.integer :upload_less_than_5, null:false
+      t.integer :upload_less_than_25, null:false
+      t.integer :upload_faster_than_100, null:false
+      t.integer :upload_faster_than_250, null:false
+
+      t.timestamps null: false
     end
+
+    execute "ALTER TABLE stats_caches ADD PRIMARY KEY (stat_type, stat_id, date_type, date_value);"
   end
-  
+end

--- a/db/migrate/20190628164100_add_stats_cache_table.rb
+++ b/db/migrate/20190628164100_add_stats_cache_table.rb
@@ -1,0 +1,28 @@
+class AddStatsCacheTable < ActiveRecord::Migration
+    def change
+      create_table :stats_cache, id: false do |t|
+        t.string :boundary_type, null:false
+        t.string :boundary_id, null:false
+        t.string :date_type, null:false
+        t.date :date_value, null:false
+
+        t.float :all_avg_upload, null:false
+        t.float :all_median_upload, null:false
+        t.integer :all_count_upload, null:false
+        t.float :all_avg_download, null:false
+        t.float :all_median_download, null:false
+        t.integer :all_count_download, null:false
+        t.float :sua_avg_upload, null:false
+        t.float :sua_median_upload, null:false
+        t.integer :sua_count_upload, null:false
+        t.float :sua_avg_download, null:false
+        t.float :sua_median_download, null:false
+        t.integer :sua_count_download, null:false
+  
+        t.timestamps null: false
+      end
+
+      execute "ALTER TABLE stats_cache ADD PRIMARY KEY (boundary_type, boundary_id, date_type, date_value);"
+    end
+  end
+  

--- a/db/migrate/20190630124800_add_census_tract_index.rb
+++ b/db/migrate/20190630124800_add_census_tract_index.rb
@@ -1,0 +1,5 @@
+class AddCensusTractIndex < ActiveRecord::Migration
+  def change
+    add_index :submissions, [:census_code]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190714031500) do
+ActiveRecord::Schema.define(version: 20190723184600) do
 
   create_table "census_boundaries", force: :cascade do |t|
     t.string   "name",            limit: 255
     t.integer  "area_identifier", limit: 4
-    t.text     "bounds",          limit: 65535
+    t.text     "bounds",          limit: 4294967295
     t.string   "geo_id",          limit: 255
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
     t.string   "geom_type",       limit: 255
   end
 
@@ -44,6 +44,27 @@ ActiveRecord::Schema.define(version: 20190714031500) do
     t.datetime "created_at",             null: false
     t.datetime "updated_at",             null: false
     t.string   "short_name", limit: 255
+  end
+
+  create_table "stats_cache", id: false, force: :cascade do |t|
+    t.string   "boundary_type",       limit: 255, null: false
+    t.string   "boundary_id",         limit: 255, null: false
+    t.string   "date_type",           limit: 255, null: false
+    t.date     "date_value",                      null: false
+    t.float    "all_avg_upload",      limit: 24,  null: false
+    t.float    "all_median_upload",   limit: 24,  null: false
+    t.integer  "all_count_upload",    limit: 4,   null: false
+    t.float    "all_avg_download",    limit: 24,  null: false
+    t.float    "all_median_download", limit: 24,  null: false
+    t.integer  "all_count_download",  limit: 4,   null: false
+    t.float    "sua_avg_upload",      limit: 24,  null: false
+    t.float    "sua_median_upload",   limit: 24,  null: false
+    t.integer  "sua_count_upload",    limit: 4,   null: false
+    t.float    "sua_avg_download",    limit: 24,  null: false
+    t.float    "sua_median_download", limit: 24,  null: false
+    t.integer  "sua_count_download",  limit: 4,   null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   create_table "submissions", force: :cascade do |t|
@@ -76,10 +97,15 @@ ActiveRecord::Schema.define(version: 20190714031500) do
     t.float    "download_median",     limit: 24
     t.string   "census_status",       limit: 10
     t.date     "test_date",                                                                 null: false
+    t.string   "country_code",        limit: 255
+    t.string   "region",              limit: 255
+    t.string   "county",              limit: 255
+    t.integer  "accuracy",            limit: 4
   end
 
   add_index "submissions", ["actual_down_speed"], name: "index_submissions_on_actual_down_speed", using: :btree
   add_index "submissions", ["census_status"], name: "index_submissions_on_census_status", using: :btree
+  add_index "submissions", ["country_code", "region", "test_type"], name: "index_submissions_on_country_code_and_region_and_test_type", using: :btree
   add_index "submissions", ["provider", "test_date", "test_type"], name: "index_submissions_on_provider_and_test_date_and_test_type", using: :btree
   add_index "submissions", ["provider"], name: "index_submissions_on_provider", using: :btree
   add_index "submissions", ["rating"], name: "index_submissions_on_rating", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,25 +46,59 @@ ActiveRecord::Schema.define(version: 20190723184600) do
     t.string   "short_name", limit: 255
   end
 
-  create_table "stats_cache", id: false, force: :cascade do |t|
-    t.string   "boundary_type",       limit: 255, null: false
-    t.string   "boundary_id",         limit: 255, null: false
-    t.string   "date_type",           limit: 255, null: false
-    t.date     "date_value",                      null: false
-    t.float    "all_avg_upload",      limit: 24,  null: false
-    t.float    "all_median_upload",   limit: 24,  null: false
-    t.integer  "all_count_upload",    limit: 4,   null: false
-    t.float    "all_avg_download",    limit: 24,  null: false
-    t.float    "all_median_download", limit: 24,  null: false
-    t.integer  "all_count_download",  limit: 4,   null: false
-    t.float    "sua_avg_upload",      limit: 24,  null: false
-    t.float    "sua_median_upload",   limit: 24,  null: false
-    t.integer  "sua_count_upload",    limit: 4,   null: false
-    t.float    "sua_avg_download",    limit: 24,  null: false
-    t.float    "sua_median_download", limit: 24,  null: false
-    t.integer  "sua_count_download",  limit: 4,   null: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
+  create_table "stats_caches", id: false, force: :cascade do |t|
+    t.string   "stat_type",                limit: 255, null: false
+    t.string   "stat_id",                  limit: 255, null: false
+    t.string   "date_type",                limit: 255, null: false
+    t.date     "date_value",                           null: false
+    t.float    "download_avg",             limit: 24,  null: false
+    t.float    "download_median",          limit: 24,  null: false
+    t.float    "download_max",             limit: 24,  null: false
+    t.integer  "download_count",           limit: 4,   null: false
+    t.float    "download_sua_avg",         limit: 24,  null: false
+    t.float    "download_sua_median",      limit: 24,  null: false
+    t.float    "download_sua_max",         limit: 24,  null: false
+    t.integer  "download_sua_count",       limit: 4,   null: false
+    t.integer  "download_0_5",             limit: 4,   null: false
+    t.integer  "download_6_10",            limit: 4,   null: false
+    t.integer  "download_11_20",           limit: 4,   null: false
+    t.integer  "download_21_40",           limit: 4,   null: false
+    t.integer  "download_40_60",           limit: 4,   null: false
+    t.integer  "download_61_80",           limit: 4,   null: false
+    t.integer  "download_81_100",          limit: 4,   null: false
+    t.integer  "download_101_250",         limit: 4,   null: false
+    t.integer  "download_251_500",         limit: 4,   null: false
+    t.integer  "download_500_1000",        limit: 4,   null: false
+    t.integer  "download_1001",            limit: 4,   null: false
+    t.integer  "download_less_than_5",     limit: 4,   null: false
+    t.integer  "download_less_than_25",    limit: 4,   null: false
+    t.integer  "download_faster_than_100", limit: 4,   null: false
+    t.integer  "download_faster_than_250", limit: 4,   null: false
+    t.float    "upload_avg",               limit: 24,  null: false
+    t.float    "upload_median",            limit: 24,  null: false
+    t.float    "upload_max",               limit: 24,  null: false
+    t.integer  "upload_count",             limit: 4,   null: false
+    t.float    "upload_sua_avg",           limit: 24,  null: false
+    t.float    "upload_sua_median",        limit: 24,  null: false
+    t.float    "upload_sua_max",           limit: 24,  null: false
+    t.integer  "upload_sua_count",         limit: 4,   null: false
+    t.integer  "upload_0_5",               limit: 4,   null: false
+    t.integer  "upload_6_10",              limit: 4,   null: false
+    t.integer  "upload_11_20",             limit: 4,   null: false
+    t.integer  "upload_21_40",             limit: 4,   null: false
+    t.integer  "upload_40_60",             limit: 4,   null: false
+    t.integer  "upload_61_80",             limit: 4,   null: false
+    t.integer  "upload_81_100",            limit: 4,   null: false
+    t.integer  "upload_101_250",           limit: 4,   null: false
+    t.integer  "upload_251_500",           limit: 4,   null: false
+    t.integer  "upload_500_1000",          limit: 4,   null: false
+    t.integer  "upload_1001",              limit: 4,   null: false
+    t.integer  "upload_less_than_5",       limit: 4,   null: false
+    t.integer  "upload_less_than_25",      limit: 4,   null: false
+    t.integer  "upload_faster_than_100",   limit: 4,   null: false
+    t.integer  "upload_faster_than_250",   limit: 4,   null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
   end
 
   create_table "submissions", force: :cascade do |t|
@@ -104,6 +138,7 @@ ActiveRecord::Schema.define(version: 20190723184600) do
   end
 
   add_index "submissions", ["actual_down_speed"], name: "index_submissions_on_actual_down_speed", using: :btree
+  add_index "submissions", ["census_code"], name: "index_submissions_on_census_code", using: :btree
   add_index "submissions", ["census_status"], name: "index_submissions_on_census_status", using: :btree
   add_index "submissions", ["country_code", "region", "test_type"], name: "index_submissions_on_country_code_and_region_and_test_type", using: :btree
   add_index "submissions", ["provider", "test_date", "test_type"], name: "index_submissions_on_provider_and_test_date_and_test_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,17 +59,17 @@ ActiveRecord::Schema.define(version: 20190723184600) do
     t.float    "download_sua_median",      limit: 24,  null: false
     t.float    "download_sua_max",         limit: 24,  null: false
     t.integer  "download_sua_count",       limit: 4,   null: false
-    t.integer  "download_0_5",             limit: 4,   null: false
-    t.integer  "download_6_10",            limit: 4,   null: false
-    t.integer  "download_11_20",           limit: 4,   null: false
-    t.integer  "download_21_40",           limit: 4,   null: false
-    t.integer  "download_40_60",           limit: 4,   null: false
-    t.integer  "download_61_80",           limit: 4,   null: false
-    t.integer  "download_81_100",          limit: 4,   null: false
-    t.integer  "download_101_250",         limit: 4,   null: false
-    t.integer  "download_251_500",         limit: 4,   null: false
-    t.integer  "download_500_1000",        limit: 4,   null: false
-    t.integer  "download_1001",            limit: 4,   null: false
+    t.float    "download_0_5",             limit: 24,  null: false
+    t.float    "download_6_10",            limit: 24,  null: false
+    t.float    "download_11_20",           limit: 24,  null: false
+    t.float    "download_21_40",           limit: 24,  null: false
+    t.float    "download_40_60",           limit: 24,  null: false
+    t.float    "download_61_80",           limit: 24,  null: false
+    t.float    "download_81_100",          limit: 24,  null: false
+    t.float    "download_101_250",         limit: 24,  null: false
+    t.float    "download_251_500",         limit: 24,  null: false
+    t.float    "download_500_1000",        limit: 24,  null: false
+    t.float    "download_1001",            limit: 24,  null: false
     t.integer  "download_less_than_5",     limit: 4,   null: false
     t.integer  "download_less_than_25",    limit: 4,   null: false
     t.integer  "download_faster_than_100", limit: 4,   null: false
@@ -82,17 +82,17 @@ ActiveRecord::Schema.define(version: 20190723184600) do
     t.float    "upload_sua_median",        limit: 24,  null: false
     t.float    "upload_sua_max",           limit: 24,  null: false
     t.integer  "upload_sua_count",         limit: 4,   null: false
-    t.integer  "upload_0_5",               limit: 4,   null: false
-    t.integer  "upload_6_10",              limit: 4,   null: false
-    t.integer  "upload_11_20",             limit: 4,   null: false
-    t.integer  "upload_21_40",             limit: 4,   null: false
-    t.integer  "upload_40_60",             limit: 4,   null: false
-    t.integer  "upload_61_80",             limit: 4,   null: false
-    t.integer  "upload_81_100",            limit: 4,   null: false
-    t.integer  "upload_101_250",           limit: 4,   null: false
-    t.integer  "upload_251_500",           limit: 4,   null: false
-    t.integer  "upload_500_1000",          limit: 4,   null: false
-    t.integer  "upload_1001",              limit: 4,   null: false
+    t.float    "upload_0_5",               limit: 24,  null: false
+    t.float    "upload_6_10",              limit: 24,  null: false
+    t.float    "upload_11_20",             limit: 24,  null: false
+    t.float    "upload_21_40",             limit: 24,  null: false
+    t.float    "upload_40_60",             limit: 24,  null: false
+    t.float    "upload_61_80",             limit: 24,  null: false
+    t.float    "upload_81_100",            limit: 24,  null: false
+    t.float    "upload_101_250",           limit: 24,  null: false
+    t.float    "upload_251_500",           limit: 24,  null: false
+    t.float    "upload_500_1000",          limit: 24,  null: false
+    t.float    "upload_1001",              limit: 24,  null: false
     t.integer  "upload_less_than_5",       limit: 4,   null: false
     t.integer  "upload_less_than_25",      limit: 4,   null: false
     t.integer  "upload_faster_than_100",   limit: 4,   null: false


### PR DESCRIPTION
This PR adds a new table that will cache nightly pre-calculated data. It also adds a much-needed index submissions.census_code.